### PR TITLE
poplar: use persistent property to disable or enable adb over usb function

### DIFF
--- a/rootfs/init.poplar.rc
+++ b/rootfs/init.poplar.rc
@@ -9,3 +9,8 @@ on fs
     mount_all ./fstab.poplar
     swapon_all ./fstab.poplar
 
+on property:persist.adb.over.usb=0
+    write /sys/kernel/debug/hisi_inno_phy/role "host"
+
+on property:persist.adb.over.usb=1
+    write /sys/kernel/debug/hisi_inno_phy/role "peripheral"


### PR DESCRIPTION
For the requirement of using usb2 port as host mode permanently, it uses
persistent property to disable or enable adb over usb function:
  - disable adb over usb: setprop persist.adb.over.usb 0
  - enable adb over usb: setprop persist.adb.over.usb 1

Signed-off-by: Jianguo Sun <sun_jianguo@hoperun.com>